### PR TITLE
fix: 给@we-debug/plugin-ui-check添加deep import索引

### DIFF
--- a/packages/runtime/plugin-ui-check/package.json
+++ b/packages/runtime/plugin-ui-check/package.json
@@ -4,6 +4,10 @@
   "description": "we-debug ui-check plugin",
   "miniprogram": "dist",
   "main": "dist/plugin.js",
+  "exports": {
+    ".": "./dist/plugin.js",
+    "./plugin": "./dist/plugin.js"
+  },
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Rollup依赖于npm包的package.json中的exports字段去进行deep import解析，目前@we-debug/core中使用了@we-debug/plugin-ui-check/plugin的import用法，但是@we-debug/plugin-ui-check还没有提供deep import索引。

该PR通过给@we-debug/plugin-ui-check的package.json上补充了exports字段，修复该问题